### PR TITLE
fix gap_fraction_profile and LAD for one layer profile

### DIFF
--- a/R/metrics_stdmetrics.R
+++ b/R/metrics_stdmetrics.R
@@ -556,29 +556,28 @@ rumple_index.numeric <- function(x, y = NULL, z = NULL, ...)
 #' @rdname nstdmetrics
 gap_fraction_profile = function(z, dz = 1, z0 = 2)
 {
-  bk <- seq(floor((min(z) - z0)/dz)*dz + z0, ceiling((max(z) - z0)/dz)*dz + z0, dz)
-
-  if (length(bk) <= 1)
+  zrange = range(z)
+  if (z0 < zrange[1])
+    z0 = floor((zrange[1]- z0)/dz)*dz + z0
+  
+  if (z0 >= zrange[2])
     return(data.frame(z = numeric(0), gf = numeric(0)))
-
-  histogram <- graphics::hist(z, breaks = bk, plot = F)
+  
+  bk <- seq(z0, ceiling((zrange[2] - z0)/dz)*dz + z0, dz)
+  
+  histogram <- graphics::hist(z, breaks = c(-Inf, bk), plot = F)
   h <- histogram$mids
-  p <- histogram$counts/sum(histogram$counts)
-
-  p <- c(p, 0)
-
+  p <- histogram$counts
+  
   cs <- cumsum(p)
-  i <- data.table::shift(cs)/cs
+  i <- cs[1:(length(cs)-1)]/cs[2:length(cs)]
+  
   i[is.na(i)] = 0
-
-  i[is.nan(i)] = NA
-
-  z = h #[-1]
-  i = i[-length(i)] #[-c(1, length(i))]
-
-  return(data.frame(z = z[z > z0], gf = i[z > z0]))
+  
+  z = h[-1]
+  
+  return(data.frame(z = z, gf = i))
 }
-
 
 #' @param k numeric. is the extinction coefficient
 #' @examples
@@ -594,10 +593,7 @@ LAD = function(z, dz = 1, k = 0.5, z0 = 2) # (Bouvier et al. 2015)
 {
   ld <- gap_fraction_profile(z, dz, z0)
 
-  if (nrow(ld) <= 2)
-    return(data.frame(z = numeric(0), lad = numeric(0)))
-
-  if (anyNA(ld))
+  if (nrow(ld) == 0)
     return(data.frame(z = numeric(0), lad = numeric(0)))
 
   lad <- ld$gf


### PR DESCRIPTION
Hi Jean-Romain,
In commit [Fix LAD if not computable](https://github.com/r-lidar/lidR/commit/c4e83c20ef28c7227a1e754893fcc3a14112e9cf) you added a few lines to return a 0 row data.frame when there is two layers or less for LAD.

I do not see the reason for that:  a unique layer with points inside (and eventually below) should still give a gap fraction and thus a LAD, no?

In that pull-request, I made the changes to do so: in LAD() I only returned a 0 row data.frame when gap_fraction_profile was returning a 0 row data.frame.

By the way, I simplified several things in `gap_fraction_profile()`, with the gap fraction being the `gf=N_out/N_in`:
- no need to compute gap fraction until `min(z)` if `min(z)<z0` --> starting from `z0` and considering the points below in a unique layer [-Inf, z0]
- the only case I see that `seq()` returns one value, i.e. (length(brk)==1) is when `z0==max(z)`, thus I changed the test.
- dividing the counts by `sum(counts)` is canceled afterwards by `shift(cs)/cs`, thus I removed that first division
- the supplementary layer with 0 counts does not bring anything (actually it is removed in the end) thus I removed it
- `i` can be computed without the need of data.table::shift (unless it is much faster then `1:length(cs)`?), thus I removed that dependency here.
- if `i=NaN`, `is.na(i)` is `TRUE` thus `i` would be set to 0 before getting to `is.nan(i)` --> I removed it as I do not see any reason for a NaN to happen here (it would be the case of i=0/0, which would never happen I think). And as a consequence `gap_fraction_profile()` will never return an `NA` value thus I removed the `anyNA` test in `LAD()`
- I removed the test `[z > z0]` at the end as I do not see any reason for it

I hope I did not missed anything.