### PR TITLE
Update io_readLAScatalog.R to handle bad .laz or .las files

### DIFF
--- a/R/io_readLAScatalog.R
+++ b/R/io_readLAScatalog.R
@@ -62,7 +62,7 @@
 #' @md
 readLAScatalog <- function(folder, progress = TRUE, select = "*", filter = "", chunk_size = 0, chunk_buffer = 30, ...)
 {
-  #assert_is_character(folder)
+  assert_is_character(folder)
 
   finfo <- file.info(folder)
 


### PR DESCRIPTION
This modification to io_readLAScatalog.R allows "catalog" to handle corrupted .laz and .laz files with bad GUID values. The bad records are simply eliminated from the catalog. This is handled by pushing file handling to a couple of separate function. I am not sure if any of this code is compatible with the current lidR coding standards, but I personally use something like this as a replacement for the catalog() function in the lidR package because I often run into corrupt laz files...

The first suggested function is .fn_progress_headers() and handles progress bar updates and wraps the process of reading headers in a try() statement. This way, if reading a header fails, the catalog() function can simply carry on. 

```r
    #wrapper for: read one file, and update progress bar
    #fails gracefully
    .fn_progress_headers=function(progress,pb,i,N,t0,...){
    
      #update progress bar
      if (progress && (Sys.time() - t0 > getOption("lidR.progress.delay"))) {
        utils::setTxtProgressBar(pb, i)
      }
    
      #run one file - fail gracefully
      try(.fn_one_header(...), silent=T)
    
    }
```

The second suggested function is basically just a functionized extraction of code that JR already has in the main script

```r
    #read one file header
    .fn_one_header = function(x,phblab){
    
          header <- rlas:::lasheaderreader(x)
          header <- LASheader(header)
          PHB <- header@PHB
          names(PHB) <- phblab
    
          #if (use_wktcs(header))
          if (T)
            PHB[["CRS"]] <- wkt(header)
          else
            PHB[["CRS"]] <- epsg(header)
    
          # Compatibility with rlas 1.3.0
          if (!is.null(PHB[["Number.of.points.by.return"]])) {
            PHB[["Number.of.1st.return"]] <- PHB[["Number.of.points.by.return"]][1]
            PHB[["Number.of.2nd.return"]] <- PHB[["Number.of.points.by.return"]][2]
            PHB[["Number.of.3rd.return"]] <- PHB[["Number.of.points.by.return"]][3]
            PHB[["Number.of.4th.return"]] <- PHB[["Number.of.points.by.return"]][4]
            PHB[["Number.of.5th.return"]] <- PHB[["Number.of.points.by.return"]][5]
            PHB[["Number.of.points.by.return"]] <- NULL
            PHB[["Global.Encoding"]] <- NULL
          }
    
          PHB$filename = x
          return(PHB)
    }
```

There are some further revisions in the body of readLAScatalog to modify how the progress bar is initiated and to handle the return of bad las or laz files including to issue a warning about the failed files. 

```r
    header <- LASheader(rlas::read.lasheader(files[1]))
    crs    <- st_crs(header)
    phblab <- make.names(names(phb(header)))
    phblab[4] <- "GUID"

    #set up progress bar
    N = length(files)
    t0 <- Sys.time()
    pb <- NULL
    i <- 0
    if(progress) pb <- utils::txtProgressBar(min = 0, max = length(files), initial = 0, style = 3)

    #get all headers - catch errors
    headers_list <- mapply(.fn_progress_headers, files, i=1:N, MoreArgs = list( phblab=phblab,progress=progress
                                                                                ,t0=t0,pb=pb, N=N), SIMPLIFY =F)
    #identify errors
    headers_err = sapply(headers_list,class) == "try-error"
    #warn errors
    if(sum(headers_err)>0) warning(paste("there were errors in", sum (headers_err)," files:", paste(files[headers_err],collapse=" ")))
    #combine remaining headers
    headers <- data.table::rbindlist(headers_list[!headers_err])
```