### PR TITLE
Improve epsg() warning message when WKT present

### DIFF
--- a/R/st_crs.R
+++ b/R/st_crs.R
@@ -269,7 +269,7 @@ setGeneric("epsg<-", function(object, value) standardGeneric("epsg<-"))
 #' @rdname st_crs
 setMethod("epsg", "LASheader", function(object, ...)
 {
-  if (use_wktcs(object))  warning("This LAS object stores the CRS as WKT. 0 returned; use 'wkt()' instead.", call. = FALSE)
+  if (use_wktcs(object))  warning("This LAS object stores the CRS as WKT. CRS field might not be correctly populated, yielding uncertain results; use 'wkt()' instead.", call. = FALSE)
   return(rlas::header_get_epsg(as.list(object)))
 })
 


### PR DESCRIPTION
EPSG code in the LAS header might be correctly populated for backwards compatability, despite also having a defined WKT as per LAS-format 1.4 requirements.
It is best for the method to return the EPSG contents but with a warning. Previous warning message ("0 returned") is untrue if EPSG is populated.
